### PR TITLE
fix link of chinese copywriting guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@
 
 #### Typesetting
 
-笔记内容按照 [中文文案排版指北](http://mazhuang.org/wiki/chinese-copywriting-guidelines/) 进行排版，以保证内容的可读性。
+笔记内容按照 [中文文案排版指北](https://mazhuang.org/wiki/chinese-copywriting-guidelines/) 进行排版，以保证内容的可读性。
 
 笔记不使用 `![]()` 这种方式来引用图片，而是用 `<img>` 标签。一方面是为了能够控制图片以合适的大小显示，另一方面是因为 GFM 不支持 `<center> ![]() </center>` 让图片居中显示，只能使用 `<div align="center"> <img src=""/> </div>` 达到居中的效果。
 


### PR DESCRIPTION
博客 enforce https 之后，原有的 http 链接失败了，麻烦合并修复一下。