### PR TITLE
修复不能访问的链接

### DIFF
--- a/notes/Java IO.md
+++ b/notes/Java IO.md
@@ -611,7 +611,7 @@ NIO 与普通 I/O 的区别主要有以下两点：
 - [Java NIO Tutorial](http://tutorials.jenkov.com/java-nio/index.html)
 - [Java NIO 浅析](https://tech.meituan.com/nio.html)
 - [IBM: 深入分析 Java I/O 的工作机制](https://www.ibm.com/developerworks/cn/java/j-lo-javaio/index.html)
-- [IBM: 深入分析 Java 中的中文编码问题](https://www.ibm.com/developerworks/cn/java/j-lo-chinesecoding/index.htm)
+- [IBM: 深入分析 Java 中的中文编码问题](https://www.ibm.com/developerworks/cn/java/j-lo-chinesecoding/index.html)
 - [IBM: Java 序列化的高级认识](https://www.ibm.com/developerworks/cn/java/j-lo-serial/index.html)
 - [NIO 与传统 IO 的区别](http://blog.csdn.net/shimiso/article/details/24990499)
 - [Decorator Design Pattern](http://stg-tud.github.io/sedc/Lecture/ws13-14/5.3-Decorator.html#mode=document)


### PR DESCRIPTION
修复不能访问的链接

原文中的链接无法访问，疑似是因为原链接漏了一个'l'字符
![image](https://user-images.githubusercontent.com/3983683/48839378-41ea9400-edc6-11e8-8195-62b00c0c9090.png)

访问原文中的链接，效果如下
![image](https://user-images.githubusercontent.com/3983683/48839426-71010580-edc6-11e8-9840-9658bb05c804.png)

