### PR TITLE
classfier->classifier

### DIFF
--- a/notes/构建工具.md
+++ b/notes/构建工具.md
@@ -96,7 +96,7 @@ POM 代表项目对象模型，它是一个 XML 文件，保存在项目根目�
 </dependency>
 ```
 
-[groupId, artifactId, version, packaging, classfier] 称为一个项目的坐标，其中 groupId、artifactId、version 必须定义，packaging 可选（默认为 Jar），classfier 不能直接定义的，需要结合插件使用。
+[groupId, artifactId, version, packaging, classifier] 称为一个项目的坐标，其中 groupId、artifactId、version 必须定义，packaging 可选（默认为 Jar），classifier 不能直接定义的，需要结合插件使用。
 
 - groupId：项目组 Id，必须全球唯一；
 - artifactId：项目 Id，即项目名；


### PR DESCRIPTION
修改两处拼写错误

在 [Maven 官网提供的文档](https://maven.apache.org/pom.html) 中，可以看到，似乎应该是 `classifier`
![image](https://user-images.githubusercontent.com/3983683/48901226-b50c0d00-ee8f-11e8-89a5-5e7a06590a0d.png)


另外，在 [Maven 官网提供的文档](https://maven.apache.org/pom.html) 中提到 
> * groupId, artifactId, version:
> You will see these elements often. This trinity is used to compute the Maven coordinate of a specific project in time, demarcating it as a dependency of this project.

我理解其大意是 groupId, artifactId, version 可以作为项目的坐标(相关部分如下图红线所示)
![image](https://user-images.githubusercontent.com/3983683/48901316-00beb680-ee90-11e8-851c-d682b38b7f19.png)
似乎和本文中的描述略有不同(本文中的相关描述如下图红线所示)
![image](https://user-images.githubusercontent.com/3983683/48901358-3368af00-ee90-11e8-89a2-a17a8b8c39e8.png)

