### PR TITLE
修改"剑指offer", 51. 数组中的逆序对

### DIFF
--- a/docs/notes/剑指 Offer 题解 - 50~59.md
+++ b/docs/notes/剑指 Offer 题解 - 50~59.md
@@ -121,11 +121,11 @@ private void merge(int[] nums, int l, int m, int h) {
             tmp[k] = nums[j++];
         else if (j > h)
             tmp[k] = nums[i++];
-        else if (nums[i] < nums[j])
+        else if (nums[i] <= nums[j])
             tmp[k] = nums[i++];
         else {
             tmp[k] = nums[j++];
-            this.cnt += m - i + 1;  // nums[i] >= nums[j]，说明 nums[i...mid] 都大于 nums[j]
+            this.cnt += m - i + 1;  // nums[i] > nums[j]，说明 nums[i...mid] 都大于 nums[j]
         }
         k++;
     }


### PR DESCRIPTION
128 行注释改为 "nums[i] > nums[j]，说明 nums[i...mid] 都大于 nums[j]"。
124 行判断添加条件当 nums[i]==nums[j] 时不增加 cnt 逆序对数量。