### PR TITLE
jvm对boolean数组的支持

### DIFF
--- a/docs/notes/Java 基础.md
+++ b/docs/notes/Java 基础.md
@@ -53,7 +53,7 @@
 - double/64
 - boolean/\~
 
-boolean 只有两个值：true、false，可以使用 1 bit 来存储，但是具体大小没有明确规定。JVM 会在编译时期将 boolean 类型的数据转换为 int，使用 1 来表示 true，0 表示 false。JVM 并不直接支持 boolean 数组，而是使用 byte 数组来表示 int 数组来表示。
+boolean 只有两个值：true、false，可以使用 1 bit 来存储，但是具体大小没有明确规定。JVM 会在编译时期将 boolean 类型的数据转换为 int，使用 1 来表示 true，0 表示 false。JVM 直接支持boolean类型的数组，它的newarry指令允许boolean数组的创建。boolean类型的数组的访问和修改则是使用byte数组指令baload和bastore。
 
 - [Primitive Data Types](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html)
 - [The Java® Virtual Machine Specification](https://docs.oracle.com/javase/specs/jvms/se8/jvms8.pdf)


### PR DESCRIPTION
原文为
 The Java Virtual Machine does directly support boolean arrays. Its newarray
instruction (§newarray) enables creation of boolean arrays. Arrays of type
boolean are accessed and modified using the byte array instructions baload and
bastore (§baload, §bastore).

https://docs.oracle.com/javase/specs/jvms/se8/jvms8.pdf  第10页