### PR TITLE
HTTP.md: fix typo

### DIFF
--- a/docs/notes/HTTP.md
+++ b/docs/notes/HTTP.md
@@ -587,7 +587,7 @@ Accept-Ranges: bytes
 
 ## 分块传输编码
 
-Chunked Transfer Coding，可以把数据分割成多块，让浏览器逐步显示页面。
+Chunked Transfer Encoding，可以把数据分割成多块，让浏览器逐步显示页面。
 
 ## 多部分对象集合
 


### PR DESCRIPTION
https://zh.wikipedia.org/wiki/%E5%88%86%E5%9D%97%E4%BC%A0%E8%BE%93%E7%BC%96%E7%A0%81