### PR TITLE
修正了 经典练习题.sql 第19题的错误

### DIFF
--- a/other/sql 经典练习题.sql
+++ b/other/sql 经典练习题.sql
@@ -203,10 +203,10 @@ ORDER BY RANK;
 -- 19、查询选修“3-105”课程的成绩高于“109”号同学成绩的所有同学的记录。
 select *
 from SCORE
-where CNO = '3-105' and DEGREE > ALL (
+where CNO = '3-105' and DEGREE > (
   select DEGREE
   from SCORE
-  where SNO = '109'
+  where SNO = '109' and CNO = '3-105'
 );
 
 set @@global.sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';


### PR DESCRIPTION
题目：
-- 19、查询选修“3-105”课程的成绩高于“109”号同学成绩的所有同学的记录。
原答案：
```sql
select *
from SCORE
where CNO = '3-105' and DEGREE > ALL (
  select DEGREE
  from SCORE
  where SNO = '109'
);
```

修改后的答案：
```sql
select *
from SCORE
where CNO = '3-105' and DEGREE > (
  select DEGREE
  from SCORE
  where SNO = '109' and CNO = '3-105'
);
```
原答案对题意理解有错误。

题目要求的是：查询选修“3-105”课程的成绩高于“109”号同学成绩的**所有同学**的记录。
原答案给的是：查询选修“3-105”课程的成绩高于“109”号同学**所有成绩**的同学的记录。