### PR TITLE
修改Java并发守护线程部分

### DIFF
--- a/notes/Java 并发.md
+++ b/notes/Java 并发.md
@@ -223,12 +223,13 @@ public static void main(String[] args) {
 
 main() 属于非守护线程。
 
-使用 setDaemon() 方法将一个线程设置为守护线程。
+在线程启动之前使用 setDaemon() 方法可以将一个线程设置为守护线程。
 
 ```java
 public static void main(String[] args) {
     Thread thread = new Thread(new MyRunnable());
     thread.setDaemon(true);
+    thread.start();
 }
 ```
 


### PR DESCRIPTION
将守护线程创建的方式叙述的更加严谨，只有在线程启动之前设置为setDaemon(true)才会有效，因为有公司面试会问到守护线程的创建方式