### PR TITLE
修改 .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-*.md linguist-language=java
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
修改后GitHub可以正确的将Repo语言识别为Markdown
![image](https://user-images.githubusercontent.com/75297777/145145989-420fa159-9064-495e-838c-1cc913ede43e.png)